### PR TITLE
Fix issues with the filter by group status feature

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -29,7 +29,6 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
 
         Set<Mod> modList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_MOD));
-        System.out.println(modList.size());
         Status groupStatus = ParserUtil.parseGroupStatus(argMultimap.getValue(PREFIX_GROUP).orElse(null));
 
         if (modList.size() > 1) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -134,7 +134,7 @@ public class ParserUtil {
         if (status != null) {
             String trimmedStatus = status.trim();
             if (!Status.isValidStatus(trimmedStatus)) {
-                throw new ParseException(Mod.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Status.MESSAGE_CONSTRAINTS);
             }
             return Status.parseStatusForFilter(trimmedStatus);
         } else {

--- a/src/main/java/seedu/address/model/tag/Status.java
+++ b/src/main/java/seedu/address/model/tag/Status.java
@@ -7,8 +7,8 @@ public enum Status {
     NEED_GROUP("SG"),
     NEED_MEMBER("SM");
 
-    public static final String MESSAGE_CONSTRAINTS = "The group status you are trying to find does not exist! " +
-            "Please enter 'SG' for 'Seeking group', 'SM' for 'Seeking member' or 'G' for 'Not looking for group'";
+    public static final String MESSAGE_CONSTRAINTS = "The group status you are trying to find does not exist! "
+            + "Please enter 'SG' for 'Seeking group', 'SM' for 'Seeking member' or 'G' for 'Not looking for group'";
 
     private String status;
 

--- a/src/main/java/seedu/address/model/tag/Status.java
+++ b/src/main/java/seedu/address/model/tag/Status.java
@@ -7,6 +7,9 @@ public enum Status {
     NEED_GROUP("SG"),
     NEED_MEMBER("SM");
 
+    public static final String MESSAGE_CONSTRAINTS = "The group status you are trying to find does not exist! " +
+            "Please enter 'SG' for 'Seeking group', 'SM' for 'Seeking member' or 'G' for 'Not looking for group'";
+
     private String status;
 
     Status(String s) {
@@ -21,14 +24,19 @@ public enum Status {
      */
     public static Status parseStatusForFilter(String status) {
         assert (status != null);
-        return Status.valueOf(status);
+        if (status.equalsIgnoreCase("SG")) {
+            return Status.NEED_GROUP;
+        } else if (status.equalsIgnoreCase("SM")) {
+            return Status.NEED_MEMBER;
+        } else {
+            return Status.NONE;
+        }
     }
 
     /**
      * Returns true if a given string is a valid status.
      */
     public static boolean isValidStatus(String test) {
-        System.out.println(Status.NONE.toString());
         return Stream.of(Status.values()).anyMatch(status -> status.toString().equalsIgnoreCase(test));
     }
 


### PR DESCRIPTION
- Fixed the issue with filter by group status
- Potential bugs we should resolve (for all features in the AB3 also): should probably be a different error message if the user uses a prefix that doesn't exist, rather than showing the MESSAGE_CONSTRAINTS of the last correct prefix used.

Eg: 
`edit 2 id/A1233215B e/email@example.com gibberish/something`

Returns: 
```
"Emails should be of the format local-part@domain and adhere to the following constraints:
1. The local-part should only contain alphanumeric characters and these special characters, excluding the parentheses, (+_.-). The local-part may not start or end with any special characters.
2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels separated by periods.
The domain name must:
    - end with a domain label at least 2 characters long
    - have each domain label start and end with alphanumeric characters
    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any."
```